### PR TITLE
[sbltnfi] discord-badge fix duplicate badge when force updating multiple times

### DIFF
--- a/sbltnfi/sbltnfi-discord-badge.user.js
+++ b/sbltnfi/sbltnfi-discord-badge.user.js
@@ -54,7 +54,7 @@ function addBadges() {
   } else {
     document.querySelectorAll("a[href^='/userid/']").forEach(elem => {
       const SBID = elem.href.split("/")[4];
-      if (elem.querySelector("#mchang-discord-badge")) return;
+      if (elem.nextSibling?.matches("#mchang-discord-badge")) return;
       lookupUser(SBID, elem);
     });
   }


### PR DESCRIPTION
When using the [force update userscript](https://gist.github.com/TheJzoli/8a4cd979d433b7359cdf61c238bc0181/), clicking the force refresh button multiple times creates duplicate discord badges. This PR fixes that.