### PR TITLE
fix dearrow videotitle script

### DIFF
--- a/sbltnfi/fork/sbltnfi-dearrow-videotitle.user.js
+++ b/sbltnfi/fork/sbltnfi-dearrow-videotitle.user.js
@@ -16,19 +16,6 @@
 // @grant        GM_addStyle
 // ==/UserScript==
 
-const getTitle = async (videoID) => {
-  const dearrowTitle = await GM_xmlhttpRequestPromise(`https://sponsor.ajay.app/api/branding?videoID=${videoID}`, {
-      responseType: "json",
-      timeout: 10000,
-    });
-  const oembedTitle = await GM_xmlhttpRequestPromise(`https://www.youtube.com/oembed?url=youtube.com/watch?v=${videoID}&format=json`, {
-      responseType: "json",
-      timeout: 10000,
-    });
-  const title = dearrowTitle?.response?.titles?.[0]?.title || oembedTitle?.response?.title;
-  return title.replace(/\s>/, " ").trim();
-};
-
 const videoIdAndRowElementObj = {};
 
 (function() {

--- a/sbltnfi/videotitle/dearrow.js
+++ b/sbltnfi/videotitle/dearrow.js
@@ -7,5 +7,5 @@ const getTitle = async (videoID) => {
       responseType: "json",
       timeout: 10000,
     });
-  return dearrowTitle?.response?.titles?.[0]?.title || oembedTitle?.response?.title;
+  return dearrowTitle?.response?.titles?.[0]?.title?.replace(/(^|\s)>(\S)/g, "$1$2")?.trim() || oembedTitle?.response?.title;
 };


### PR DESCRIPTION
- https://uscript.mchang.xyz/sbltnfi/videotitle/dearrow.js already defines `getTitle`, so the script throws an error.
- ">" isn't handled properly; copied the logic from https://github.com/ajayyy/DeArrow/blob/131f8106359fc767641089897aa0efff4a1aa0ae/src/titles/titleFormatter.ts#L473